### PR TITLE
Remove hourly rate-limiting enforcement

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -30,8 +30,6 @@ module.exports = {
   IssuesPerRequest,
   ViolationCategory,
   RATE_LIMIT: {
-    REQUESTS_PER_HOUR: 950,
-    HOUR_IN_MS: 3600000,
     THROTTLE_DELAY_MS: 200,
     DEFAULT_RETRIES: 5,
     BASE_RETRY_DELAY_MS: 1000

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ inquirer
         return new Promise((resolve, reject) => {
           if (
             /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/.test(
-              input
+              input,
             )
           ) {
             resolve(true);
@@ -62,14 +62,18 @@ inquirer
     },
     {
       type: "input",
+      name: "scanGroups",
+      message:
+        "Filter by Scan Group(s)? Enter Scan group names separated by commas, or press Enter for All:",
+      default: "All",
+    },
+    {
+      type: "input",
       name: "projectid",
       message:
-        "List all Scan Id(s) for which  you'd like to export, separated by a comma (i.e. 24,15,215). Scan Id can be found in your Axe Monitor URL (Example URL https://axemonitor.dequecloud.com/monitor/scans/16 with 16 being the Scan ID).",
-      when: (answers) => {
-        if (answers.path === "issues" || answers.path === "pages") {
-          return true;
-        }
-      },
+        "Filter by Scan ID(s)? Enter IDs separated by commas (e.g. 24,15,215), or press Enter for All. Scan ID can be found in your Axe Monitor URL (e.g. https://axemonitor.dequecloud.com/monitor/scans/16, where 16 is the Scan ID).",
+      default: "All",
+      when: (answers) => answers.path === "issues" || answers.path === "pages",
     },
     {
       type: "list",

--- a/src/issueReports.js
+++ b/src/issueReports.js
@@ -6,32 +6,49 @@ const utilClassInstance = require("./utils");
 const limit = plimit(4);
 
 module.exports = async (answers) => {
-  let { projectid, includeNeedsReview } = answers;
-
-  let projectids = projectid.split(",").map((id) => parseInt(id));
+  let { projectid, includeNeedsReview, scanGroups } = answers;
 
   const { allAvailableProjects, getIssuesOfProject, generateExcel, generateJSON } =
     utilClassInstance;
 
-  // Validate project IDs (store messages for later logging)
-  const validationMessages = [];
-  projectids.forEach((id) => {
-    if (isNaN(id)) {
-      validationMessages.push(`Invalid project ID: ${id} 👾`);
-    } else if (
-      allAvailableProjects.findIndex((project) => project.id === id) === -1
-    ) {
-      validationMessages.push(
-        `Project with ID ${id} is not available or inaccessible. Ignoring it. 🫠`
-      );
-    }
-  });
+  // Apply scan group filter
+  let filteredProjects = allAvailableProjects;
+  if (scanGroups && scanGroups.trim().toLowerCase() !== "all") {
+    const filterGroups = scanGroups.split(",").map((g) => g.trim().toLowerCase());
+    filteredProjects = allAvailableProjects.filter(
+      (scan) =>
+        scan.groups &&
+        scan.groups.some((g) => filterGroups.includes(g.name.toLowerCase()))
+    );
+  }
 
-  projectids = projectids.filter(
-    (id) =>
-      !isNaN(id) &&
-      allAvailableProjects.findIndex((project) => project.id === id) !== -1
-  );
+  // Resolve project IDs: "All" uses every project in the filtered set
+  let projectids;
+  const validationMessages = [];
+
+  if (!projectid || projectid.trim().toLowerCase() === "all") {
+    projectids = filteredProjects.map((p) => p.id);
+  } else {
+    projectids = projectid.split(",").map((id) => parseInt(id));
+
+    projectids.forEach((id) => {
+      if (isNaN(id)) {
+        validationMessages.push(`Invalid project ID: ${id} 👾`);
+      } else if (
+        allAvailableProjects.findIndex((project) => project.id === id) === -1
+      ) {
+        validationMessages.push(
+          `Project with ID ${id} is not available or inaccessible. Ignoring it. 🫠`
+        );
+      }
+    });
+
+    projectids = projectids.filter(
+      (id) =>
+        !isNaN(id) &&
+        allAvailableProjects.findIndex((project) => project.id === id) !== -1
+    );
+  }
 
   if (projectids.length === 0) {
     console.log("No valid project IDs provided. Exiting... 👋");

--- a/src/pageReports.js
+++ b/src/pageReports.js
@@ -6,32 +6,49 @@ const utilClassInstance = require("./utils");
 const limit = plimit(4);
 
 module.exports = async (answers) => {
-  let { projectid } = answers;
-
-  let projectids = projectid.split(",").map((id) => parseInt(id));
+  let { projectid, scanGroups } = answers;
 
   const { allAvailableProjects, getPagesData, generateExcel, generateJSON } =
     utilClassInstance;
 
-  // Validate project IDs (store messages for later logging)
-  const validationMessages = [];
-  projectids.forEach((id) => {
-    if (isNaN(id)) {
-      validationMessages.push(`Invalid project ID: ${id} 👾`);
-    } else if (
-      allAvailableProjects.findIndex((project) => project.id === id) === -1
-    ) {
-      validationMessages.push(
-        `Project with ID ${id} is not available or inaccessible. Ignoring it. 🫠`
-      );
-    }
-  });
+  // Apply scan group filter
+  let filteredProjects = allAvailableProjects;
+  if (scanGroups && scanGroups.trim().toLowerCase() !== "all") {
+    const filterGroups = scanGroups.split(",").map((g) => g.trim().toLowerCase());
+    filteredProjects = allAvailableProjects.filter(
+      (scan) =>
+        scan.groups &&
+        scan.groups.some((g) => filterGroups.includes(g.name.toLowerCase()))
+    );
+  }
 
-  projectids = projectids.filter(
-    (id) =>
-      !isNaN(id) &&
-      allAvailableProjects.findIndex((project) => project.id === id) !== -1
-  );
+  // Resolve project IDs: "All" uses every project in the filtered set
+  let projectids;
+  const validationMessages = [];
+
+  if (!projectid || projectid.trim().toLowerCase() === "all") {
+    projectids = filteredProjects.map((p) => p.id);
+  } else {
+    projectids = projectid.split(",").map((id) => parseInt(id));
+
+    projectids.forEach((id) => {
+      if (isNaN(id)) {
+        validationMessages.push(`Invalid project ID: ${id} 👾`);
+      } else if (
+        allAvailableProjects.findIndex((project) => project.id === id) === -1
+      ) {
+        validationMessages.push(
+          `Project with ID ${id} is not available or inaccessible. Ignoring it. 🫠`
+        );
+      }
+    });
+
+    projectids = projectids.filter(
+      (id) =>
+        !isNaN(id) &&
+        allAvailableProjects.findIndex((project) => project.id === id) !== -1
+    );
+  }
 
   if (projectids.length === 0) {
     console.log("No valid project IDs provided. Exiting... 👋");

--- a/src/scanReports.js
+++ b/src/scanReports.js
@@ -8,12 +8,21 @@ const { getScanDetails, generateExcel, delay, generateJSON } = utilClassInstance
 
 const limit = plimit(2);
 
-module.exports = async ({ url }) => {
+module.exports = async ({ url, scanGroups }) => {
   const results = [];
 
   try {
     //allScans:[{id:Int, name: String, group:[String]}] = [{id: 1, name: 'https://www.example.com', group:[]},...];
     let allScans = utilClassInstance.allAvailableProjects;
+
+    if (scanGroups && scanGroups.trim().toLowerCase() !== "all") {
+      const filterGroups = scanGroups.split(",").map((g) => g.trim().toLowerCase());
+      allScans = allScans.filter(
+        (scan) =>
+          scan.groups &&
+          scan.groups.some((g) => filterGroups.includes(g.name.toLowerCase()))
+      );
+    }
 
     if (allScans.length === 0) {
       console.log("No projects found. Exiting... 👋");

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,8 +27,6 @@ class Utils {
     this.getMultipleScanDetails = this.getMultipleScanDetails.bind(this);
     this.getPagesData = this.getPagesData.bind(this);
     this.getIssuesOfProject = this.getIssuesOfProject.bind(this);
-    this.requestCount = 0;
-    this.requestStartTime = Date.now();
     this.progressBar = null;
   }
 
@@ -229,29 +227,7 @@ class Utils {
   delay = (ms) => new Promise((res) => setTimeout(res, ms));
 
   throttledAxios = async (config) => {
-    const now = Date.now();
-    if (now - this.requestStartTime >= RATE_LIMIT.HOUR_IN_MS) {
-      this.requestCount = 0;
-      this.requestStartTime = now;
-    }
-
-    if (this.requestCount >= RATE_LIMIT.REQUESTS_PER_HOUR) {
-      const waitTime = RATE_LIMIT.HOUR_IN_MS - (now - this.requestStartTime);
-      const message = `⚠️ Hourly limit reached. Waiting ${Math.ceil(waitTime / 1000)} seconds...`;
-      
-      if (this.progressBar && typeof this.progressBar.log === 'function') {
-        this.progressBar.log(message, 'warn');
-      } else {
-        console.warn(message);
-      }
-      
-      await this.delay(waitTime);
-      this.requestCount = 0;
-      this.requestStartTime = Date.now();
-    }
-
     await this.delay(RATE_LIMIT.THROTTLE_DELAY_MS);
-    this.requestCount++;
     return axios({ ...config, httpsAgent: agent });
   };
 


### PR DESCRIPTION
Simplify request throttling by removing the hourly request cap and its tracking logic. Removed REQUESTS_PER_HOUR and HOUR_IN_MS from src/constants.js, deleted requestCount and requestStartTime fields in Utils, and stripped the code that waited/logged when the hourly limit was reached. throttledAxios now only applies RATE_LIMIT.THROTTLE_DELAY_MS before issuing requests.